### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -17,7 +17,7 @@
 		<language></language>
         <platform>all</platform>
 		<license>GNU General Public License v2.0</license>
-		<forum></forum>
+		<forum>http://forum.kodi.tv/showthread.php?tid=207968</forum>
 		<website>www.9gag.tv</website>
 		<email>kodi at bromix dot org</email>
 		<source>https://github.com/bromix/plugin.video.9gagtv</source>


### PR DESCRIPTION
Needed to automatically fill the links in http://kodi.wiki and http://addons.kodi.tv/ sites.